### PR TITLE
Change compile keyword to implementation for Gradle 7+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thing-it/cordova-plugin-local-notification",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Schedules and queries for local notifications",
   "cordova": {
     "id": "cordova-plugin-local-notification",

--- a/plugin.xml
+++ b/plugin.xml
@@ -48,7 +48,7 @@
 
     <!-- dependencies -->
     <dependency id="cordova-plugin-device" />
-    <dependency id="cordova-plugin-badge" version=">=0.8.5" />
+    <dependency id="cordova-plugin-badge" version=">=0.8.8" />
 
     <!-- js -->
     <js-module src="www/local-notification.js" name="LocalNotification">

--- a/plugin.xml
+++ b/plugin.xml
@@ -24,7 +24,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-local-notification"
-        version="1.0.1">
+        version="1.0.2">
 
     <name>LocalNotification</name>
 

--- a/src/android/build/localnotification.gradle
+++ b/src/android/build/localnotification.gradle
@@ -27,5 +27,5 @@ if (!project.ext.has('appShortcutBadgerVersion')) {
 }
 
 dependencies {
-    compile "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
+    implementation "me.leolin:ShortcutBadger:${appShortcutBadgerVersion}@aar"
 }


### PR DESCRIPTION
With the upgrade to [cordova-android 11](https://cordova.apache.org/announcements/2022/07/12/cordova-android-release-11.0.0.html) the Android builds are now done with `Gradle 7.4.2`. Gradle removed the `compile` keyword with version 7.x. As [described by Gradle](https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal), the keyword is to be replaced by `implementation`.
- Bump `cordova-plugin-badge` dependency to `0.8.8`.